### PR TITLE
feat(just): add bootc-image-builder step + use buildah for build

### DIFF
--- a/image-builder.config.toml
+++ b/image-builder.config.toml
@@ -1,0 +1,8 @@
+[[customizations.user]]
+name = "ultramarine"
+password = "ultramarine"
+groups = ["wheel"]
+
+[[customizations.filesystem]]
+mountpoint = "/"
+minsize = "20 GiB"

--- a/justfile
+++ b/justfile
@@ -1,49 +1,32 @@
-# registry_auth := "auth.json"
-# ostree_cache := "/cache"
-# ostree_repo := "ostree-repo"
-# initialize := "--initialize"
-# images_dir := "/images"
+registry_prefix := "ghcr.io/ultramarine-linux"
+build variant:
+  buildah bud -t {{ registry_prefix }}/{{ variant }}-bootc {{ variant }}
 
-# prep:
-#   [ -d {{ostree_cache}} ] || mkdir -p {{ostree_cache}}
-#   [ -d {{ostree_repo}} ] || ostree init --repo={{ostree_repo}}
-#   [ -d {{images_dir}} ] || mkdir -p {{images_dir}}
+build-vm image type="qcow2":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  TARGET_IMAGE={{ image }}
 
-# clean-cache:
-#   sudo rm -rf {{ ostree_cache }}
-
-# clean-variant variant:
-#   rm -rf ./out/{{variant}}
-
-# clean-out:
-#   rm -rf ./out
-
-# clean-repo:
-#   rm -rf ./{{ostree_repo}}
-
-# clean-images:
-#   rm -rf ./{{images_dir}}
-
-# clean: clean-cache clean-out clean-repo clean-images
-
-# compile variant: (clean-variant variant)
-#   melody compile ultramarine/{{variant}}.yaml out/{{variant}}
-
-# compose-tree variant:
-#   sudo rpm-ostree compose tree --cachedir={{ostree_cache}} --repo={{ostree_repo}} --unified-core out/{{variant}}/0.yaml
-
-# compose-image variant:
-#   sudo rpm-ostree compose image --cachedir={{ostree_cache}} {{initialize}} out/{{variant}}/0.yaml {{images_dir}}/$(echo "{{variant}}" | tr / -)-{{arch()}}.tar
-
-# build-tree variant: prep (compile variant) (compose-tree variant)
-# build-image variant: prep (compile variant) (compose-image variant)
-
-image_name := "ghcr.io/ultramarine/base-standalone-bootc"
-
-build-base-standalone:
-  sudo buildah build --security-opt=label=disable --cap-add=all --device /dev/fuse -t {{image_name}} base-standalone 
-
-
+  if ! sudo podman image exists $TARGET_IMAGE ; then
+    echo "Ensuring image is on root storage"
+    sudo podman image scp $USER@localhost::$TARGET_IMAGE root@localhost:: 
+  fi
   
-
-
+  echo "Cleaning up previous build"
+  sudo rm -rf output || true
+  mkdir -p output
+  sudo podman run \
+    --rm \
+    -it \
+    --privileged \
+    --pull=newer \
+    --security-opt label=type:unconfined_t \
+    -v $(pwd)/image-builder.config.toml:/config.toml:ro \
+    -v $(pwd)/output:/output \
+    -v /var/lib/containers/storage:/var/lib/containers/storage \
+    quay.io/centos-bootc/bootc-image-builder:latest \
+    --type {{ type }} \
+    --rootfs btrfs \
+    --local \
+    $TARGET_IMAGE
+  sudo chown -R $USER:$USER output


### PR DESCRIPTION
This just adds a bootc-image-builder step so that we can test these out a bit easier. - And also moves the build step to buildah (since those flags on podman build dont seem to be required)
